### PR TITLE
Fan control fix

### DIFF
--- a/tools/setAMDGPUFanSpeed.sh
+++ b/tools/setAMDGPUFanSpeed.sh
@@ -91,7 +91,9 @@ if [  "$GPUSEQ" == "all" ]; then
 fi
 
 enable="1"
-readarray -td '' a < <(awk '{ gsub(/,[ ]*|$/,"\0"); print }' <<<"$gpusequence, "); unset 'a[-1]';
+# Simplify readarray parsing for simple CSV string
+readarray -td, a <<<"$gpusequence, "; unset 'a[-1]';
+#readarray -td '' a < <(awk '{ gsub(/,[ ]*|$/,"\0"); print }' <<<"$gpusequence, "); unset 'a[-1]';
 
 for gpunumber in "${a[@]}"
 do


### PR DESCRIPTION
The `readarray` parser in `setAMDGPUFanSpeed.sh` resulted in a null array on my system, due to an error with the `gsub` filter. This prevented the script from setting any fan speeds.

Simplifying the `readarray` to parse a simple CSV list of GPUs fixed the issue on my system.
